### PR TITLE
Fix option aggregation and parsing

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -33,6 +33,9 @@ int main(int argc, char *argv[]){
     while ((opt = getopt_long(argc, argv, optstring, long_options, &option_index)) != -1){
 
         switch (opt) {
+            case 0:
+                /* plugin-specific option parsed */
+                break;
             case 'A':
                 A_flag = true;
                 opt_used_counter[A_USED] += 1;


### PR DESCRIPTION
## Summary
- collect built-in and plugin options correctly
- skip non-plugin files when searching for plugins
- duplicate plugin option names to avoid invalid pointers
- accept plugin options in the main parsing loop

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68547463dd7c832089692b3b219bb147